### PR TITLE
Update for React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "react": "^0.12.2",
     "reactify": "^1.0.0",
     "vinyl-source-stream": "^1.0.0"
+  },
+  "dependencies": {
+    "react": "^0.14.2",
+    "react-addons-perf": "^0.14.2"
   }
 }

--- a/perf.js
+++ b/perf.js
@@ -1,5 +1,5 @@
-var React = require('react/addons')
-  , Perf = require('react/addons').addons.Perf
+var React = require('react')
+  , Perf = require('react-addons-perf')
   ;
 module.exports = {
   getInitialState: function(){


### PR DESCRIPTION
`Perf` is no longer part of the react package but it's now it's own thing. This fixes the library for React >= 0.14
